### PR TITLE
ADD: Ability to import fonts

### DIFF
--- a/lib/stylio/app.rb
+++ b/lib/stylio/app.rb
@@ -28,6 +28,10 @@ module Stylio
       settings.javascripts["application.js"]
     end
 
+    get '/fonts/:file' do
+      File.read(File.join(settings.app_path, 'assets', 'fonts', params[:file]))
+    end
+
     get '/elements' do
       file = File.join(settings.app_path, 'elements')
       if File.exist?("#{file}.erb")

--- a/lib/stylio/version.rb
+++ b/lib/stylio/version.rb
@@ -1,3 +1,3 @@
 module Stylio
-  VERSION = "0.0.8"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
This PR:

- Adds the ability for Stylio apps to use fonts in /assets/fonts (This has font-awesome support in mind)
- Adds .DS_Store to the global .gitignore
- Bumps version to 0.1.0 and rebuilds gem.