### PR TITLE
ADD: CLI refactoring and generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Stylesheets are added to the `assets/stylesheets` folder which you will need to 
 
 ## Adding components
 
-`mkdir components/COMPONENT_NAME` and then add two files in this folder:
+`bundle exec stylio generate-component COMPONENT_NAME` which will add two files in this folder:
 
 An erb partial `touch _COMPONENT_NAME.html.erb`
 A fixture file `touch COMPONENT_NAME.yml`

--- a/bin/stylio
+++ b/bin/stylio
@@ -5,13 +5,24 @@ $LOAD_PATH.unshift(lib) if File.directory?(lib) && !$LOAD_PATH.include?(lib)
 
 require 'bundler/setup'
 require 'stylio'
+require 'thor'
+require 'colorize'
 
-args = ARGV.dup
-ARGV.clear
-command = args.shift.strip rescue 'help'
+class StylioCLI < Thor
+  desc 'generate-component [NAME]', 'generate a component with NAME'
+  def generate_component(name)
+    require_relative '../lib/stylio/generators/component'
+    Stylio::Generators::Component.new(name).generate
+  end
 
-Bundler.require :default
+  desc 'up', 'start stylio on port 4567'
+  def up
+    puts 'Starting Stylio...'.green
+    Stylio::App.new
+    Stylio::App.set :app_path, Dir.pwd
+    Stylio::App.run!
+  end
+  default_task :up
+end
 
-Stylio::App.new
-Stylio::App.set :app_path, Dir.pwd
-Stylio::App.run!
+StylioCLI.start(ARGV)

--- a/lib/stylio/assets.rb
+++ b/lib/stylio/assets.rb
@@ -34,7 +34,7 @@ module Sinatra
         }).render
       end
 
-      %w{jpg png}.each do |format|
+      %w(jpg png).each do |format|
         app.get "/assets/images/:image.#{format}" do |image|
           content_type("image/#{format}")
           File.join(options.assets, "images", "#{image}.#{format}")

--- a/lib/stylio/generators/component.rb
+++ b/lib/stylio/generators/component.rb
@@ -1,0 +1,27 @@
+require 'colorize'
+module Stylio
+  module Generators
+    class Component
+      attr_reader :name
+
+      def initialize(name)
+        @name = name
+      end
+
+      def generate
+        puts "Generating component with name #{name}".yellow
+        FileUtils::mkdir_p "components/#{name}"
+        puts "Created folder components/#{name}".green
+        File.open("components/#{name}/#{name}.yml", 'w') do |f|
+          f.write('')
+        end
+        puts "Created file components/#{name}/#{name}.yml".green
+        File.open("components/#{name}/#{name}.html.erb", 'w') do |f|
+          f.write('')
+        end
+        puts "Created file components/#{name}/#{name}.html.erb".green
+        puts "Generated component with name #{name}".green
+      end
+    end
+  end
+end

--- a/lib/stylio/version.rb
+++ b/lib/stylio/version.rb
@@ -1,3 +1,3 @@
 module Stylio
-  VERSION = "0.0.8"
+  VERSION = "0.1.0"
 end

--- a/stylio.gemspec
+++ b/stylio.gemspec
@@ -24,6 +24,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sprockets"
   spec.add_dependency "uglifier"
   spec.add_dependency "coffee-script"
+  spec.add_dependency "thor"
+  spec.add_dependency "thin"
+  spec.add_dependency "colorize"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This commit adds a few things:

* The Thor gem for better CLI support. You can now run bin/stylio up to start (this is also the default command to preserve backwards compatibility).
* You can also run bin/stylio generate-component [COMPONENT-NAME] to generate the files for a component.
* bin/stylio help will now provide help on these new commands.
* It replaces webBrick with Thin as the default web server. It appears to be considerably quicker.